### PR TITLE
samsung: fastcharge: chown sysfs node on init

### DIFF
--- a/hidl/fastcharge/vendor.lineage.fastcharge@1.0-service.samsung.rc
+++ b/hidl/fastcharge/vendor.lineage.fastcharge@1.0-service.samsung.rc
@@ -1,3 +1,6 @@
+on init
+    chown system radio /sys/class/sec/switch/afc_disable
+
 service vendor.fastcharge-hal-1-0 /vendor/bin/hw/vendor.lineage.fastcharge@1.0-service.samsung
     class hal
     user system


### PR DESCRIPTION
Change-Id: I04d04b89534293cda68fe2499b9dca4fe962c804